### PR TITLE
Corys contributions

### DIFF
--- a/process_emails.ipynb
+++ b/process_emails.ipynb
@@ -6,8 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install neo4j pinecone-client pinecone-notebooks\n",
-    "! pip install kaggle getpass"
+    "! pip install neo4j pinecone-client pinecone-notebooks openai\n",
+    "! pip install kaggle getpass "
    ]
   },
   {
@@ -19,11 +19,19 @@
     "# Let's set some environment variables\n",
     "# We'll use Pinecone Connect to set the Pinecone API key\n",
     "from pinecone_notebooks.colab import Authenticate\n",
+    "\n",
+    "Authenticate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We'll use getpass to set the Neo4j and Kaggle credentials\n",
     "import getpass, os\n",
     "\n",
-    "Authenticate()\n",
-    "\n",
-    "# We'll use getpass to set the Neo4j and Kaggle credentials\n",
     "for env in ['NEO4J_URI', 'NEO4J_USER', 'NEO4J_PASSWORD', 'KAGGLE_USERNAME', 'KAGGLE_KEY']:\n",
     "    os.environ[env] = getpass.getpass(f\"Please enter the value for {env}: \")"
    ]


### PR DESCRIPTION
## Problem

The dataset being used was not locally available and had to be downloaded separately from the notebook. Also, the auth credentials for both Pinecone and Neo4j were using locally scoped environment variables, but there was no `.env` skeleton file to store them. This could result in confusion on how to authenticate to those systems. 

## Solution

Added `kaggle` Python module to make downloading the dataset(s) easier, and also cleaned up the auth for Pinecone and Neo4j. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Loaded the notebook in Colab and ran through it manually, confirming it works. 