### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in this repo.
+* @pinecone-io/dev-advocates @pinecone-io/sdk


### PR DESCRIPTION
Adds a CODEOWNERS file so review requests (including the maintenance fleet's fix-PRs) route to the owning team(s): `* @pinecone-io/dev-advocates @pinecone-io/sdk`.

Backfill for a repo already in the groundskeeper maintenance fleet's managed set (`.github/managed-repos.json`). A human reviews and merges — this is opened, not merged.