### PR TITLE
ci: add JS audit gate + Dependabot coverage for Python deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,18 @@ updates:
           - minor
           - patch
 
+  # Python dependencies for the data scripts (poetry).
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
   # GitHub Actions used by the CI workflow.
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,17 @@ jobs:
       - name: Build
         run: pnpm run build
 
+      - name: Dependency audit (fail on high or critical)
+        run: |
+          pnpm audit --json > pnpm-audit.json || true
+          COUNT=$(node -e "const v=require('./pnpm-audit.json').metadata.vulnerabilities;console.log((v.high||0)+(v.critical||0))")
+          echo "high+critical vulnerabilities: $COUNT"
+          if [ "$COUNT" -gt 0 ]; then
+            echo "::error::High or critical dependency vulnerabilities found"
+            pnpm audit --audit-level=high || true
+            exit 1
+          fi
+
   python:
     name: Lint & smoke-check (python)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Brings `pinecone-neo4j-explorer` closer to the standard CI bar. Existing CI already lints/tests/builds the Next.js `explorer` app and lint+compile-checks the Python scripts, with least-privilege permissions and concurrency cancellation. This adds:

1. **JS dependency audit gate** — a step in the `build` job that fails on **high/critical** pnpm advisories. It parses `pnpm audit --json` for the high+critical count rather than using `pnpm audit --audit-level=high`, because pnpm's exit code for `--audit-level` is unreliable (it exits non-zero even when only low/moderate advisories exist — verified locally). Currently **0 high / 0 critical** (2 low, 8 moderate), so CI is green.
2. **Dependabot coverage for the Python deps** — adds a `pip` ecosystem for the root poetry project. Previously Dependabot only watched the JS app and GitHub Actions; the Python data-script dependencies had no coverage.

## Verification (local)

- `pnpm audit --json` → metadata vulnerabilities: `{low: 2, moderate: 8, high: 0, critical: 0}`; the gate's high+critical count is 0 → **passes**.
- Both YAML files validated.

## Follow-ups (not in this PR)

- A Python-side CI audit (`pip-audit`) would complement the new Dependabot pip coverage — left out here since it needs a verified poetry-env run.
- The 8 moderate advisories (mostly Svelte SSR XSS in a transitive dep) are below the gate; Dependabot will surface fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)